### PR TITLE
Disabled overscroll behaviour for vertical scrolling in docs

### DIFF
--- a/src/base/base.sss
+++ b/src/base/base.sss
@@ -51,6 +51,7 @@ html
 body
   -webkit-tap-highlight-color: rgba(#000, 0)
   line-height: 1.7
+  overscroll-behavior-y: none;
 
 *:focus
   outline: none


### PR DESCRIPTION
Hey! I recently checked out docs of the project and while used those, I noticed that page "jumping" on MacOS when page scrolled too far. On my feelings, experience is more pleasant when this behaviour disabled, hope this change is not too subjective :)