### PR TITLE
use pug tag interpolation

### DIFF
--- a/src/uikit.pug
+++ b/src/uikit.pug
@@ -129,7 +129,7 @@ html( lang="en" )
             a.title_link( href="#home" title="Direct link to section" )
               | Logux.io UI Kit
           a.edit_link( href="https://github.com/logux/logux.io" title="Edit the page on GitHub" )
-        p.text_block Logux <strong>actions</strong> are very similar to <strong><a href="#">Redux actions</a></strong>. JSON objects describe what was changed in <a href="#">the application state</a>. Logux Core provides <code class="code">BaseNode</code> class, which will synchronize actions between two nodes. <code class="code">ClientNode</code> and <code class="code">ServerNode</code> classes extend this class with small behaviour changes.
+        p.text_block Logux #[strong actions] are very similar to #[strong #[a(href="#") Redux actions]]. JSON objects describe what was changed in #[a(href="#") the application state]. Logux Core provides #[code.code BaseNode] class, which will synchronize actions between two nodes. #[code.code ClientNode] and #[code.code ServerNode] classes extend this class with small behaviour changes.
         +switcher('Node.js', 'Ruby on Rails')
           +switcher_section
             p.text_block You can use only string, number, boolean, null, array, and object as values.
@@ -140,13 +140,13 @@ html( lang="en" )
                 p.text_block You can use only string, number, boolean, null, array, and object as values.
             ul.list
               li
-                p.text_block The <code class="code">standard Redux</code> way to dispatch actions. Action will not be sent to the server or another browser tab. There is no way to set action’s meta in this method.
+                p.text_block The #[code.code standard Redux] way to dispatch actions. Action will not be sent to the server or another browser tab. There is no way to set action’s meta in this method.
                 pre.code-block server.undo(meta, <span class="code-block_string">'too late'</span>)
               li
-                p.text_block <code class="code">preadd</code>: action is going to be added to the log. It is the only way to set <a href="#" class="code"><code>meta.reasons</code></a>. This event will not be called for cross-tab actions added in a different browser tab.
-            p.text_block To stop the server press <kbd class="code">Command</kbd>+<kbd class="code">.</kbd> on Mac OS X and <kbd class="code">Ctrl</kbd>+<kbd class="code">C</kbd> on Linux and Windows.
+                p.text_block #[code.code preadd]: action is going to be added to the log. It is the only way to set #[a.code(href="#") #[code meta.reasons]]. This event will not be called for cross-tab actions added in a different browser tab.
+            p.text_block To stop the server press #[kbd.code Command]+#[kbd.code .] on Mac OS X and #[kbd.code Ctrl]+#[kbd.code C] on Linux and Windows.
           +switcher_section
-            p.text_block Clients can also create <code class="code">logux/undo</code> to revert action and ask other clients to revert it (if the developer allowed to re-send these actions on the server).
+            p.text_block Clients can also create #[code.code logux/undo] to revert action and ask other clients to revert it (if the developer allowed to re-send these actions on the server).
           .next
             a.button( href="#" )
               | Next chapter
@@ -183,7 +183,7 @@ html( lang="en" )
           a.source( href="#" title="Source code" )
           a.title_link( href="#add" title="Direct link to section" )
             code
-              | <span class="title_extra">Class.</span>add<span class="title_extra">(action, meta)</span>
+              | #[span.title_extra Class.]add#[span.title_extra (action, meta)]
         h3#parameters.title
           a.title_link( href="#parameters" title="Direct link to section" ) Parameters
         table.table
@@ -192,20 +192,20 @@ html( lang="en" )
             th Type
             th Description
           tr
-            td <code class="code">log</code>
-            td <code><a href="#">Log</a></code>
+            td: code.code log
+            td: code: a(href="#") Log
             td Unique current machine name.
           tr
-            td <code class="code">reason</code>
-            td <code>string = 'error'</code>
+            td: code.code reason
+            td: code string = 'error'
             td Optional code for reason.
           tr
-            td <code class="code">opts.allowDangerousProtocol</code>
-            td <code>boolean?</code>
-            td Do not show warning when using <code class="code">ws://</code> in production
+            td: code.code opts.allowDangerousProtocol
+            td: code boolean?
+            td Do not show warning when using #[code.code ws://] in production
         h3#returns.title
           a.title_link( href="#returns" title="Direct link to section" ) Returns
-        p.text_block <code><a href="#">Promise</a>&lt;<a href="#">boolean</a>&gt;</code>
+        p.text_block: code #[a(href="#") Promise]&lt;#[a(href="#") boolean]&gt;
         hr.line
 
       article.text
@@ -226,18 +226,18 @@ html( lang="en" )
       footer.footer
         section.footer_section
           h3.footer_title About
-          .footer_link <a href="/guide/">Guide</a>
-          .footer_link <a href="/recipes/">Recipes</a>
-          .footer_link <a href="/node-api/">Node API</a>
-          .footer_link <a href="/web-api/">Web API</a>
-          .footer_link <a href="/protocols/">Protocols</a>
+          .footer_link: a(href="/guide/") Guide
+          .footer_link: a(href="/recipes/") Recipes
+          .footer_link: a(href="/node-api/") Node API
+          .footer_link: a(href="/web-api/") Web API
+          .footer_link: a(href="/protocols/") Protocols
         section.footer_section
           h3.footer_title Community
-          .footer_link <a href="https://github.com/logux">GitHub</a>
-          .footer_link <a href="https://twitter.com/logux_io">Twitter</a>
-          .footer_link <a href="https://gitter.im/logux/logux">Gitter</a>
-          .footer_link <a href="https://twitter.com/linguopunk">Linguopunk</a>
+          .footer_link: a(href="https://github.com/logux") GitHub
+          .footer_link: a(href="https://twitter.com/logux_io") Twitter
+          .footer_link: a(href="https://gitter.im/logux/logux") Gitter
+          .footer_link: a(href="https://twitter.com/linguopunk") Linguopunk
         section.footer_section.is-author
-          .footer_text Under the <a href="https://github.com/logux/logux.io/blob/master/LICENSE" rel="license">MIT</a> license
-          .footer_text Sponsored by <a href="https://evilmartians.com/">Evil Martians</a>
+          .footer_text Under the #[a(href="https://github.com/logux/logux.io/blob/master/LICENSE" rel="license") MIT] license
+          .footer_text Sponsored by #[a(href="https://evilmartians.com/") Evil Martians]
           a.footer_lurkers( href="https://evilmartians.com/" aria-hidden="true" tabindex="-1" )


### PR DESCRIPTION
Remove all own source HTML from Pug template.

`pre.code-block` content looks like code highlighting library output so I decided to not change it.