### PR TITLE
Remove redundant touch-action

### DIFF
--- a/src/base/base.sss
+++ b/src/base/base.sss
@@ -24,7 +24,6 @@ html
   font-family: "Work Sans", sans-serif
   font-size: 18px
   color: var(--base-text)
-  touch-action: manipulation
   background: var(--base-background)
 
   @mixin mobile


### PR DESCRIPTION
There is `<meta name="viewport" content="width=device-width">` on the site already. So touch-action is redundant in this case.

https://developers.google.com/web/updates/2013/12/300ms-tap-delay-gone-away