### PR TITLE
Add margin to code block to right side

### DIFF
--- a/src/code-block/code-block.sss
+++ b/src/code-block/code-block.sss
@@ -7,6 +7,9 @@
   background: var(--base-panel)
   box-shadow: var(--base-above)
 
+  span
+    margin-right: 10px
+
   &:focus
     box-shadow: var(--base-above-focus)
 


### PR DESCRIPTION
I have added the margin to right side for code block that is bigger then screen:

Before:
<img width="466" alt="Screen Shot 2019-12-21 at 10 25 25" src="https://user-images.githubusercontent.com/48512663/71306115-a10d4480-23dc-11ea-9c0b-7abb9c137eec.png">

After:
<img width="430" alt="Screen Shot 2019-12-21 at 10 25 35" src="https://user-images.githubusercontent.com/48512663/71306114-9f438100-23dc-11ea-9bd4-438139f83e22.png">

If I did it in wrong way, please feel free to add comments and I will change my PR.