### PR TITLE
Fixed text overflow in "Skip navigation" link

### DIFF
--- a/src/menu/menu.sss
+++ b/src/menu/menu.sss
@@ -27,11 +27,8 @@ a.menu_skip
     top: 9px
     right: 9px
     left: 9px
-    height: 39px
-    padding: 0 12px
-    line-height: 39px
+    padding: 5px 12px
     color: var(--base-title)
-    white-space: nowrap
     background: var(--base-panel)
     border-radius: 4px
 


### PR DESCRIPTION
With a menu width of 150px, the "Skip navigation" text overflows the link boundaries:

<img width="345" alt="1" src="https://user-images.githubusercontent.com/5951118/71409991-8cd37c80-2654-11ea-986c-4c7659030c1b.png">

After fix:

<img width="339" alt="2" src="https://user-images.githubusercontent.com/5951118/71409998-9361f400-2654-11ea-9dad-88723a8fd5cb.png">
