### PR TITLE
Add groupings to Logux API

### DIFF
--- a/scripts/steps/build-api.js
+++ b/scripts/steps/build-api.js
@@ -883,7 +883,9 @@ function toTree(ctx, nodes) {
 }
 
 function submenuName(node) {
-  return node.name + (node.kindString === 'Function' ? '()' : '')
+  let nodeNameWithoutPrefix = node.name.replace(/^(react|vue)\./i, '')
+
+  return nodeNameWithoutPrefix + (node.kindString === 'Function' ? '()' : '')
 }
 
 function toSubmenu(nodes) {

--- a/scripts/steps/build-api.js
+++ b/scripts/steps/build-api.js
@@ -765,7 +765,7 @@ function toTree(ctx, nodes) {
 }
 
 function submenuName(node) {
-  return node.name + (node.kind === 'function' ? '()' : '')
+  return node.name + (node.kindString === 'Function' ? '()' : '')
 }
 
 function toSubmenu(nodes) {

--- a/scripts/steps/build-api.js
+++ b/scripts/steps/build-api.js
@@ -106,45 +106,104 @@ const UNWRAP_UTILITIES = new Set([
 
 const EXCLUDED_SUBMENU_KINDS = new Set(['Type alias', 'Interface', 'Namespace'])
 const EXCLUDED_TREE_KINDS = new Set(['Namespace'])
+const CORE_ENTITIES = new Set([
+  'BaseNode',
+  'Connection',
+  'Log',
+  'MemoryStore',
+  'Reconnect',
+  'ServerConnection',
+  'defineAction',
+  'isFirstOlder',
+  'parseId'
+])
+const CLIENT_ENTITIES = new Set([
+  'Client',
+  'CrossTabClient',
+  'IndexedStore',
+  'attention',
+  'badge',
+  'buildNewSyncMap',
+  'changeSyncMap',
+  'changeSyncMapById',
+  'confirm',
+  'createFilter',
+  'createSyncMap',
+  'defineSyncMap',
+  'deleteSyncMap',
+  'deleteSyncMapById',
+  'encryptActions',
+  'favicon',
+  'log',
+  'request'
+])
+const SERVER_ENTITIES = new Set([
+  'ChannelContext',
+  'Context',
+  'ResponseError',
+  'Server',
+  'ServerClient',
+  'del',
+  'get',
+  'patch',
+  'post',
+  'put',
+  'request'
+])
+const STATE_ENTITIES = new Set([
+  'createDerived',
+  'createMap',
+  'createPersistent',
+  'createRouter',
+  'createStore',
+  'getPagePath',
+  'getValue',
+  'openPage'
+])
+const TEST_ENTITIES = new Set([
+  'TestClient',
+  'TestLog',
+  'TestPair',
+  'TestServer',
+  'TestTime',
+  'cleanStores',
+  'emptyInTest',
+  'prepareForTest'
+])
 
 const GROUPS = {
-  Actions: 'Actions',
   Client: 'Client',
   Core: 'Core',
   Other: 'Other',
   React: 'React',
   Server: 'Server',
-  State: 'State',
+  State: 'Logux State',
   Tests: 'Tests',
-  Types: 'Types',
   Vue: 'Vue'
 }
 
 // More specific group conditions should be placed higher
 const GROUPS_CONDITION = {
-  [GROUPS.Types]: node =>
-    node.kindString === 'Type alias' || node.kindString === 'Interface',
   [GROUPS.React]: node => isSource(node, 'react'),
   [GROUPS.Vue]: node => isSource(node, 'vue'),
-  [GROUPS.Tests]: node => isSource(node, 'test'),
-  [GROUPS.Actions]: node => isSource(node, 'logux-actions'),
-  [GROUPS.Client]: node => isSource(node, 'logux-client'),
-  [GROUPS.Core]: node => isSource(node, 'logux-core'),
-  [GROUPS.Server]: node => isSource(node, 'logux-server'),
-  [GROUPS.State]: node => isSource(node, 'logux-state')
+  [GROUPS.Tests]: node => TEST_ENTITIES.has(node.name),
+  [GROUPS.Client]: node =>
+    CLIENT_ENTITIES.has(node.name) && isSource(node, 'logux-client'),
+  [GROUPS.Core]: node => CORE_ENTITIES.has(node.name),
+  [GROUPS.Server]: node =>
+    SERVER_ENTITIES.has(node.name) && isSource(node, 'logux-server'),
+  [GROUPS.State]: node => STATE_ENTITIES.has(node.name)
 }
 
 const GROUPS_ORDER = [
-  GROUPS.Core,
-  GROUPS.Client,
-  GROUPS.Server,
-  GROUPS.Actions,
   GROUPS.State,
-  GROUPS.Tests,
   GROUPS.React,
   GROUPS.Vue,
-  GROUPS.Other,
-  GROUPS.Types
+  GROUPS.Client,
+  GROUPS.Server,
+  GROUPS.Tests,
+  GROUPS.Core,
+  GROUPS.Other
 ]
 
 function toSlug(type) {

--- a/scripts/steps/build-api.js
+++ b/scripts/steps/build-api.js
@@ -803,7 +803,6 @@ function toTree(ctx, nodes) {
     }
 
     return tag('article', [
-      tag('h1', groupName, { noSlug: true }),
       ...group.map(node => {
         if (node.kindString === 'Class') {
           return classHtml(ctx, node)

--- a/scripts/steps/build-api.js
+++ b/scripts/steps/build-api.js
@@ -175,6 +175,7 @@ const GROUPS = {
   Client: 'Client',
   Core: 'Core',
   Other: 'Other',
+  Preact: 'Preact',
   React: 'React',
   Server: 'Server',
   State: 'Logux State',
@@ -184,8 +185,9 @@ const GROUPS = {
 
 // More specific group conditions should be placed higher
 const GROUPS_CONDITION = {
-  [GROUPS.React]: node => isSource(node, 'react'),
-  [GROUPS.Vue]: node => isSource(node, 'vue'),
+  [GROUPS.React]: node => /^react\./i.test(node.name),
+  [GROUPS.Vue]: node => /^vue\./i.test(node.name),
+  [GROUPS.Preact]: node => /^preact\./i.test(node.name),
   [GROUPS.Tests]: node => TEST_ENTITIES.has(node.name),
   [GROUPS.Client]: node =>
     CLIENT_ENTITIES.has(node.name) && isSource(node, 'logux-client'),
@@ -199,6 +201,7 @@ const GROUPS_ORDER = [
   GROUPS.State,
   GROUPS.React,
   GROUPS.Vue,
+  GROUPS.Preact,
   GROUPS.Client,
   GROUPS.Server,
   GROUPS.Tests,
@@ -883,7 +886,7 @@ function toTree(ctx, nodes) {
 }
 
 function submenuName(node) {
-  let nodeNameWithoutPrefix = node.name.replace(/^(react|vue)\./i, '')
+  let nodeNameWithoutPrefix = node.name.replace(/^(preact|react|vue)\./i, '')
 
   return nodeNameWithoutPrefix + (node.kindString === 'Function' ? '()' : '')
 }

--- a/scripts/steps/create-layout.js
+++ b/scripts/steps/create-layout.js
@@ -242,7 +242,7 @@ function converter() {
         if (node.editUrl) {
           node.tagName = 'div'
           node.children = [
-            tag('h1', 'class_title', node.properties, node.children),
+            tag('h1', 'title', node.properties, node.children),
             tag('a', 'edit_link', {
               title: 'Edit the page on GitHub',
               href: node.editUrl

--- a/scripts/steps/create-layout.js
+++ b/scripts/steps/create-layout.js
@@ -8,7 +8,8 @@ import unified from 'unified'
 import { addError } from '../lib/errors.js'
 import wrap from '../lib/spinner.js'
 
-const SMALL_WORDS = /(^|\s)(the|a|for|in|an|to|if|so|when|with|by|and|or|is|this|any|from) /gi
+const SMALL_WORDS =
+  /(^|\s)(the|a|for|in|an|to|if|so|when|with|by|and|or|is|this|any|from) /gi
 
 function cleaner({ chatUsers, removeAssets }) {
   return tree => {
@@ -241,7 +242,7 @@ function converter() {
         if (node.editUrl) {
           node.tagName = 'div'
           node.children = [
-            tag('h1', 'title', node.properties, node.children),
+            tag('h1', 'class_title', node.properties, node.children),
             tag('a', 'edit_link', {
               title: 'Edit the page on GitHub',
               href: node.editUrl

--- a/src/title/title.sss
+++ b/src/title/title.sss
@@ -1,15 +1,23 @@
+.class_title,
 .title
   line-height: 1.2
   color: var(--base-title)
 
 h1.title
   @mixin no-mobile
-    margin-top: 42px
     margin-bottom: 24px
     font-size: 48px
 
   @mixin mobile
-    margin-top: 24px
+    margin-bottom: 24px
+    font-size: 24px
+
+h1.class_title
+  @mixin no-mobile
+    margin-bottom: 24px
+    font-size: 48px
+
+  @mixin mobile
     margin-bottom: 24px
     font-size: 24px
 

--- a/src/title/title.sss
+++ b/src/title/title.sss
@@ -1,23 +1,15 @@
-.class_title,
 .title
   line-height: 1.2
   color: var(--base-title)
 
 h1.title
   @mixin no-mobile
+    margin-top: 42px
     margin-bottom: 24px
     font-size: 48px
 
   @mixin mobile
-    margin-bottom: 24px
-    font-size: 24px
-
-h1.class_title
-  @mixin no-mobile
-    margin-bottom: 24px
-    font-size: 48px
-
-  @mixin mobile
+    margin-top: 24px
     margin-bottom: 24px
     font-size: 24px
 


### PR DESCRIPTION
Performed the task https://cultofmartians.com/tasks/logux-api-sections.html#task

- Implemented grouping using variables `GROUPS_CONDITION` and `GROUPS_ORDER`. Adding each entity name to constants seemed redundant, so I decided to implement it through the conditions of belonging to the project name (but the pointwise addition of entities remaine possible)
- Fixed styles after grouping, because the margin between class entity title and group title was large

Also found that the API page contain many `h1` headings. Looks like that is not very semantic layout so I can fix this in this PR if it needed. And maybe remove prefixes for React and Vue group entities (like `React.useFilters()`)?

Sorry if I misunderstood task, I will be waiting for feedback